### PR TITLE
fixed tuple in __init__.py

### DIFF
--- a/colorlover/__init__.py
+++ b/colorlover/__init__.py
@@ -1724,7 +1724,7 @@ def to_rgb( scale ):
     for ea in scale:
         h,s,l = [ float(x) for x in ea ]
         r,g,b = colorsys.hls_to_rgb(h/360.0, l/100.0, s/100.0)
-        r,g,b = [ str(int(round(x*255.0))) for x in r,g,b ]
+        r,g,b = [ str(int(round(x*255.0))) for x in (r,g,b) ]
         rgb_str = 'rgb(' + ', '.join([r,g,b]) + ')'
         rgb.append( rgb_str )
         


### PR DESCRIPTION
On Python 3.3.5, Anaconda 2.2.0, on Windows 8.1, this line threw a syntax error when importing the library.
