### PR TITLE
Add classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,10 @@ setup(
   author_email = 'jack@plot.ly',
   url = 'https://github.com/jackparmer/colorlover', # use the URL to the github repo
   keywords = ['ipython notebook','color scales'], # arbitrary keywords
-  classifiers = [],
+  classifiers = [
+    # https://pypi.org/pypi?%3Aaction=list_classifiers
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
+  ],
 )


### PR DESCRIPTION
Classifiers are metadata about packages on PyPI. The information about Python version support shows on the PyPI project page and are used by tools such as [caniusepython3](https://caniusepython3.com/).