### PR TITLE
HSL fixes

### DIFF
--- a/colorlover/__init__.py
+++ b/colorlover/__init__.py
@@ -1809,14 +1809,19 @@ def interp(scl, r):
         Fun usage in IPython notebook:
         HTML( to_html( to_hsl( interp( cl.scales['11']['qual']['Paired'], 5000 ) ) ) ) '''
     c = []
-    SCL_FI = len(scl)-1 # final index of color scale
-    # garyfeng:
-    # the following line is buggy.
-    # r = [x * 0.1 for x in range(r)] if isinstance( r, int ) else r
-    r = [x*1.0*SCL_FI/r for x in range(r)] if isinstance( r, int ) else r
-    # end garyfeng
 
     scl = to_numeric( scl )
+    if isinstance(r, int):
+        if r == 0:
+            r_steps = []
+        elif r == 1:
+            # Midway point
+            r_steps = [(len(scl) / 2) - 1]
+        else:
+            # Linearly space r from 0 to len(scl) - 1
+            r_steps = [x*1.0*(len(scl) - 1)/(r-1) for x in range(r)]
+    else:
+        r_steps = r
 
     def interp3(fraction, start, end):
         ''' Interpolate between values of 2, 3-member tuples '''
@@ -1827,13 +1832,13 @@ def interp(scl, r):
 
         return (int(round(h*60,4)), int(round(s*100,4)), int(round(l*100,4)))
 
-    for i in r:
         # garyfeng: c_i could be rounded up so scl[c_i+1] will go off range
         #c_i = int(i*math.floor(SCL_FI)/round(r[-1])) # start color index
         #c_i = int(math.floor(i*math.floor(SCL_FI)/round(r[-1]))) # start color index
         #c_i = if c_i < len(scl)-1 else hsl_o
 
         c_i = int(math.floor(i))
+    for i in r_steps:
         section_min = math.floor(i)
         section_max = math.ceil(i)
         fraction = (i-section_min) #/(section_max-section_min)

--- a/colorlover/__init__.py
+++ b/colorlover/__init__.py
@@ -1778,6 +1778,32 @@ def flipper( scl=None ):
             flipped[subkey][key] = subval
     return flipped
 
+
+def rgb_to_hsl(rgb):
+    ''' Adapted from M Bostock's RGB to HSL converter in d3.js
+        https://github.com/mbostock/d3/blob/master/src/color/rgb.js '''
+    r,g,b = float(rgb[0])/255.0,\
+            float(rgb[1])/255.0,\
+            float(rgb[2])/255.0
+    mx = max(r, g, b)
+    mn = min(r, g, b)
+    h = s = l = (mx + mn) / 2
+    if mx == mn: # achromatic
+        h = 0
+        s = 0 if l > 0 and l < 1 else h
+    else:
+        d = mx - mn;
+        s =  d / (mx + mn) if l < 0.5 else d / (2 - mx - mn)
+        if mx == r:
+            h = (g - b) / d + ( 6 if g < b else 0 )
+        elif mx == g:
+            h = (b - r) / d + 2
+        else:
+            h = (r - g) / d + 4
+
+    return (int(round(h*60,4)), int(round(s*100,4)), int(round(l*100,4)))
+
+
 def interp(scl, r):
     ''' Interpolate a color scale "scl" to a new one with length "r"
         Fun usage in IPython notebook:
@@ -1798,27 +1824,6 @@ def interp(scl, r):
             return s + (e - s)*f
         return tuple([intp(fraction, start[i], end[i]) for i in range(3)])
 
-    def rgb_to_hsl(rgb):
-        ''' Adapted from M Bostock's RGB to HSL converter in d3.js
-            https://github.com/mbostock/d3/blob/master/src/color/rgb.js '''
-        r,g,b = float(rgb[0])/255.0,\
-                float(rgb[1])/255.0,\
-                float(rgb[2])/255.0
-        mx = max(r, g, b)
-        mn = min(r, g, b)
-        h = s = l = (mx + mn) / 2
-        if mx == mn: # achromatic
-            h = 0
-            s = 0 if l > 0 and l < 1 else h
-        else:
-            d = mx - mn;
-            s =  d / (mx + mn) if l < 0.5 else d / (2 - mx - mn)
-            if mx == r:
-                h = (g - b) / d + ( 6 if g < b else 0 )
-            elif mx == g:
-                h = (b - r) / d + 2
-            else:
-                h = (r - g) / d + 4
 
         return (int(round(h*60,4)), int(round(s*100,4)), int(round(l*100,4)))
 

--- a/colorlover/__init__.py
+++ b/colorlover/__init__.py
@@ -1818,7 +1818,7 @@ def interp(scl, r):
             elif mx == g:
                 h = (b - r) / d + 2
             else:
-                h = r - g / d + 4
+                h = (r - g) / d + 4
 
         return (int(round(h*60,4)), int(round(s*100,4)), int(round(l*100,4)))
 

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,27 @@ import unittest
 import colorlover as cl
 
 
+rgb_hsl_colors = {
+            (0, 0, 0): 	(0, 0, 0),  # Black
+            (255, 255, 255): 	(0, 0, 100),  # White
+            (255, 0, 0): 	(0, 100, 50),  # Red
+            (0, 255, 0): 	(120, 100, 50),  # Lime
+            (0, 0, 255): 	(240, 100, 50),  # Blue
+            (255, 255, 0): 	(60, 100, 50),  # Yellow
+            (0, 255, 255): 	(180, 100, 50),  # Cyan
+            (255, 0, 255): 	(300, 100, 50),  # Magenta
+            (192, 192, 192): 	(0, 0, 75),  # Silver
+            (128, 128, 128): 	(0, 0, 50),  # Gray
+            (128, 0, 0): 	(0, 100, 25),  # Maroon
+            (128, 128, 0): 	(60, 100, 25),  # Olive
+            (0, 128, 0): 	(120, 100, 25),  # Green
+            (128, 0, 128): 	(300, 100, 25),  # Purple
+            (0, 128, 128): 	(180, 100, 25),  # Teal
+            (0, 0, 128): 	(240, 100, 25),  # Navy
+            (20, 30, 128): 	(234, 72, 29)  # Near navy
+}
+
+
 class UsageTests(unittest.TestCase):
     def test_scales(self):
         scales = cl.scales['3']['div']['RdYlBu']
@@ -51,6 +72,13 @@ class UsageTests(unittest.TestCase):
             flipped,
             ['rgb(252,141,89)', 'rgb(255,255,191)', 'rgb(145,191,219)']
         )
+
+    def test_rgb_to_hsl(self):
+        # Make sure interpolating a colorscale to the same length does nothing
+        # but change colorspace from hsl to rgb
+        for rgb, expected_hsl in rgb_hsl_colors.items():
+            hsl = cl.rgb_to_hsl(rgb)
+            self.assertEqual(hsl, expected_hsl)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes  #18 by interpolating the `Hue` component of HSL colors as angles (rather that a pure linear interpolation).  For example, the angle half way between 10 deg and 350 deg should be 0 not 180.

Also fixed an error in the calculation of the Hue component in `rgb_to_hsl` (971ef35)

Results:
![screen shot 2019-01-19 at 10 37 42 am](https://user-images.githubusercontent.com/15064365/51428830-4b318a80-1bd6-11e9-8fa4-dcbf74c0b5a8.png)


