### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+include tests.py


### PR DESCRIPTION
This lets users make sure their installation is correct, particularly downstream packagers.